### PR TITLE
Open the TTY device in non-blocking mode

### DIFF
--- a/api.go
+++ b/api.go
@@ -36,17 +36,17 @@ func Init() error {
 		tty = "/dev/tty1"
 	}
 	if runtime.GOOS == "openbsd" || runtime.GOOS == "freebsd" {
-		out, err = os.OpenFile(tty, os.O_RDWR, 0)
+		out, err = os.OpenFile(tty, os.O_RDWR|syscall.O_NONBLOCK, 0)
 		if err != nil {
 			return err
 		}
 		in = int(out.Fd())
 	} else {
-		out, err = os.OpenFile(tty, os.O_WRONLY, 0)
+		out, err = os.OpenFile(tty, os.O_WRONLY|syscall.O_NONBLOCK, 0)
 		if err != nil {
 			return err
 		}
-		in, err = syscall.Open(tty, syscall.O_RDONLY, 0)
+		in, err = syscall.Open(tty, syscall.O_RDONLY|syscall.O_NONBLOCK, 0)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This prevents stuck situation when opening serial port devices.

Co-authored-by: gitlawr <lawrleegle@gmail.com>
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>